### PR TITLE
change .travis.yml, add LICENSE and README for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   # - python setup.py test
-  - cd docs && make html && mv ./build/html ./build/docs && rm -r ./build/doctrees && cd ..
+  - cd docs && make html && mv ./build/html ./build/docs && rm -r ./build/doctrees && mv LICENSE.txt ./build && mv README.md ./build && cd ..
   
 deploy:
   - provider: pages

--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 thu-coai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Document for Task-oriented Dialog Toolkits
+
+### Project
+
+Please refer to (comming soon).
+
+### Github Pages
+
+https://thu-coai.github.io/tatk_docs/
+
+### License
+
+MIT License


### PR DESCRIPTION
在docs目录下添加了README和LICENSE，修改.travis.yml，它会将README和LICENSE复制到html文档所在目录，一并提交