### PR TITLE
change docstring, add evaluator/__init__.py, change last two `import`…

### DIFF
--- a/tatk/dialog_agent/session.py
+++ b/tatk/dialog_agent/session.py
@@ -19,6 +19,7 @@ class Session(metaclass=ABCMeta):
     @abstractmethod
     def next_response(self, observation):
         """Generated the next response.
+        
         Args:
             observation (str or dict): The agent observation of next agent.
         Returns:
@@ -78,6 +79,7 @@ class BiSession(Session):
         Conduct a new turn of dialog, which consists of the system response and user response.
         The variable type of responses can be either 1) str or 2) dialog act, depends on the dialog mode settings of the
         two agents which are supposed to be the same.
+        
         Args:
             last_observation: Last agent response.
         Returns:

--- a/tatk/dst/state_tracker.py
+++ b/tatk/dst/state_tracker.py
@@ -9,8 +9,7 @@ class Tracker(metaclass=ABCMeta):
         """ Update the internal dialog state variable.
 
         Args:
-            dialog_act (str or dict): The type is str when Tracker is word-level (such as NBT), and dict when it is
-                    DA-level.
+            dialog_act (str or dict): The type is str when Tracker is word-level (such as NBT), and dict when it is DA-level.
         Returns:
             new_state (tuple): Updated dialog state, with the same form of previous state.
         """

--- a/tatk/nlg/nlg.py
+++ b/tatk/nlg/nlg.py
@@ -8,6 +8,7 @@ class NLG(metaclass=ABCMeta):
     def generate(self, action):
         """
         Generate a natural language utterance conditioned on the dialog act.
+        
         Args:
             action (dict): The dialog action produced by dialog policy module, which is in dialog act format.
         Returns:

--- a/tatk/nlu/nlu.py
+++ b/tatk/nlu/nlu.py
@@ -8,6 +8,7 @@ class NLU(metaclass=ABCMeta):
     def predict(self, utterance):
         """
         Predict the dialog act of a natural language utterance.
+        
         Args:
             utterance (str): A natural language utterance.
         Returns:

--- a/tatk/policy/policy.py
+++ b/tatk/policy/policy.py
@@ -7,6 +7,7 @@ class Policy(metaclass=ABCMeta):
     @abstractmethod
     def predict(self, state):
         """Predict the next agent action given dialog state.
+        
         Args:
             state (tuple or dict): when the DST and Policy module are separated, the type of state is tuple.
                     else when they are aggregated together, the type of state is dict (dialog act).

--- a/tatk/policy/rule.py
+++ b/tatk/policy/rule.py
@@ -3,8 +3,8 @@ import torch
 import numpy as np
 import logging
 from tatk.policy.policy import Policy
-from tatk.policy.policy.multiwoz.rule_based_multiwoz_bot import RuleBasedMultiwozBot
-from tatk.policy.policy.multiwoz.policy_agenda_multiwoz import UserPolicyAgendaMultiWoz
+from tatk.policy.multiwoz.rule_based_multiwoz_bot import RuleBasedMultiwozBot
+from tatk.policy.multiwoz.policy_agenda_multiwoz import UserPolicyAgendaMultiWoz
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/tatk/policy/vector.py
+++ b/tatk/policy/vector.py
@@ -14,6 +14,7 @@ class Vector():
     def state_vectorize(self, state):
         """
         vectorize a state
+
         Args:
             state (tuple): Dialog state
         Returns:
@@ -24,6 +25,7 @@ class Vector():
     def action_devectorize(self, action_vec):
         """
         recover an action
+        
         Args:
             action_vec (np.array): Dialog act vector
         Returns:


### PR DESCRIPTION
## 文档相关的问题

- tatk.policy.policy.Policy:
    - predict: Args前空一行

- tatk.policy.vector.Vector:
    - state_vectorize: Args前空一行
    - action_devectorize: Args前空一行

- tatk.nlu.nlu.NLU:
    - predict: Args前空一行

- tatk.nlg.nlg.NLG：
    - generate： Args前空一行

- tatk.dst.state_tracker.Tracker：
    - update： “DA-level.”缩进不对，或者不换行也行

- tatk.dialog_agent.agent.PipelineAgent:
    - 类的文档字符串: "The valid module combinations are as follows:", 但我还不知道怎么改

- tatk.dialog_agent.session.BiSession:
    - next_turn: Args前空一行

- tatk.dialog_agent.session.Session:
    - next_response: Args前空一行

## 其他问题

- tatk.policy.rule:
    - 修改最后两个import语句（from tatk.policy.policy.multiwoz... import ...）
- evaluator:
    - 添加\__init__.py

